### PR TITLE
Relax peer version requirement for prettier.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "peerDependencies": {
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
-        "prettier": "2.7.1"
+        "prettier": "^2.7.1"
     }
 }


### PR DESCRIPTION
Not sure how strict the peer version requirement of prettier needs to be.

To strengthen again if problem occurs.